### PR TITLE
Add lepton theme `proton-style` variants

### DIFF
--- a/themes/lepton.yaml
+++ b/themes/lepton.yaml
@@ -14,3 +14,5 @@ variants:
   default: {}
   photon-style:
     branch: photon-style
+  proton-style:
+    branch: proton-style


### PR DESCRIPTION
Lepton theme ver 3.0 will be supported `proton-style` variants

https://github.com/black7375/Firefox-UI-Fix/issues/109